### PR TITLE
Profile Reconfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -469,13 +469,12 @@
 			</build>
 		</profile>
 
-		<!-- Enable this profile to build the aggregated updatesite "updatesite.aggr" 
-			with the CBI aggregator within a project -->
+		<!-- Builds the aggregated updatesite "updatesite.aggr", if existing, with the CBI aggregator -->
 		<profile>
 			<id>aggregated-updatesite</id>
 			<activation>
 				<file>
-					<exists>.maven_enable_configuration-aggregated-updatesite</exists>
+					<exists>updatesite.aggr</exists>
 				</file>
 			</activation>
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
 			<url>http://download.eclipse.org/releases/2020-12</url>
 		</repository>
 		<repository>
-			<id>Eclipse Updates</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/eclipse/updates/4.18</url>
-		</repository>
-		<repository>
 			<id>Vitruv License</id>
 			<layout>p2</layout>
 			<url>http://vitruv-tools.github.io/updatesite/release/license</url>

--- a/pom.xml
+++ b/pom.xml
@@ -179,47 +179,11 @@
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
 					<version>3.0.0</version>
-					<executions>
-						<execution>
-							<id>generate-ecore</id>
-							<phase>none</phase>
-							<goals>
-								<goal>java</goal>
-							</goals>
-							<configuration>
-								<mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
-								<classpathScope>compile</classpathScope>
-								<includePluginDependencies>true</includePluginDependencies>
-								<cleanupDaemonThreads>false</cleanupDaemonThreads>
-								<!-- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=475098#c3 -->
-							</configuration>
-						</execution>
-					</executions>
 					<dependencies>
 						<dependency>
 							<groupId>org.eclipse.emf</groupId>
 							<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
 							<version>${mwe2.version}</version>
-						</dependency>
-						<dependency>
-							<groupId>org.eclipse.emf</groupId>
-							<artifactId>org.eclipse.emf.mwe2.lib</artifactId>
-							<version>${mwe2.version}</version>
-						</dependency>
-						<dependency>
-							<groupId>org.eclipse.emf</groupId>
-							<artifactId>org.eclipse.emf.codegen</artifactId>
-							<version>${emf-codegen.version}</version>
-						</dependency>
-						<dependency>
-							<groupId>org.eclipse.emf</groupId>
-							<artifactId>org.eclipse.emf.codegen.ecore</artifactId>
-							<version>${ecore-codegen.version}</version>
-						</dependency>
-						<dependency>
-							<groupId>org.eclipse.emf</groupId>
-							<artifactId>org.eclipse.emf.mwe.utils</artifactId>
-							<version>${mwe.version}</version>
 						</dependency>
 						<dependency>
 							<groupId>org.eclipse.xtext</groupId>
@@ -391,73 +355,118 @@
 			</build>
 		</profile>
 
-		<!-- Enable this profile to generate metamodels from .genmodel files with the project, based on an MWE2 workflow.
-			Set the property "pathToMetamodelGenerationWorkflow" to the local project-relative path of the metamodel generation workflow. 
-			Set the property "metamodelGenerationTargetFolder" to the local project-relative path of the code generation folder".
-			Add an empty ".maven_enable_metamodel-generation" file to the project to enable the profile. -->
+		<!-- Runs "workflow/clean.mwe2" workflow in clean phase, if existing -->
 		<profile>
-			<id>metamodel-generation</id>
+			<id>mwe2-cleanup</id>
 			<activation>
 				<file>
-					<exists>.maven_enable_metamodel-generation</exists>
+					<exists>workflow/clean.mwe2</exists>
 				</file>
 			</activation>
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-clean-plugin</artifactId>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>gen-clean</id>
+								<id>clean-mwe2</id>
+								<phase>clean</phase>
+								<goals>
+									<goal>java</goal>
+								</goals>
 								<configuration>
-									<filesets combine.children="append">
-										<fileset>
-											<directory>${metamodelGenerationTargetFolder}</directory>
-											<includes>
-												<include>**/*</include>
-											</includes>
-										</fileset>
-									</filesets>
+									<mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
+									<arguments>
+										<argument>/${project.basedir}/workflow/clean.mwe2</argument>
+										<argument>-p</argument>
+										<argument>rootPath=/${project.basedir}/..</argument>
+									</arguments>
+									<classpathScope>compile</classpathScope>
+									<includePluginDependencies>true</includePluginDependencies>
+									<cleanupDaemonThreads>false</cleanupDaemonThreads>
+									<!-- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=475098#c3 -->
 								</configuration>
 							</execution>
 						</executions>
 					</plugin>
 
+					<!-- Define Xtend here to ensure that it is always executed after exec-maven-plugin when occuring in same phase -->
+					<plugin>
+						<groupId>org.eclipse.xtend</groupId>
+						<artifactId>xtend-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		<!-- Runs "workflow/generate.mwe2" workflow in generate-source phase, if existing, with dependencies for Ecore
+			metamodel code generation. If further dependencies are required, e.g., for Xtext language builds, add them
+			to the plugin via pluginManagement -->
+		<profile>
+			<id>mwe2-execution</id>
+			<activation>
+				<file>
+					<exists>workflow/generate.mwe2</exists>
+				</file>
+			</activation>
+			<build>
+				<plugins>
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>generate-ecore</id>
+								<id>execute-mwe2</id>
 								<phase>generate-sources</phase>
+								<goals>
+									<goal>java</goal>
+								</goals>
 								<configuration>
+									<mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
 									<arguments>
-										<argument>/${project.basedir}/${pathToMetamodelGenerationWorkflow}</argument>
+										<argument>/${project.basedir}/workflow/generate.mwe2</argument>
 										<argument>-p</argument>
 										<argument>rootPath=/${project.basedir}/..</argument>
 									</arguments>
+									<classpathScope>compile</classpathScope>
+									<includePluginDependencies>true</includePluginDependencies>
+									<cleanupDaemonThreads>false</cleanupDaemonThreads>
+									<!-- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=475098#c3 -->
 								</configuration>
 							</execution>
 						</executions>
+						<dependencies>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.mwe2.lib</artifactId>
+							<version>${mwe2.version}</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.codegen</artifactId>
+							<version>${emf-codegen.version}</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.codegen.ecore</artifactId>
+							<version>${ecore-codegen.version}</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.mwe.utils</artifactId>
+							<version>${mwe.version}</version>
+						</dependency>
+						</dependencies>
 					</plugin>
 
+					<!-- Define Xtend here to ensure that it is always executed after exec-maven-plugin when occuring in same phase -->
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>compile-metamodel-code</id>
-								<phase>compile</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-						</executions>
+						<groupId>org.eclipse.xtend</groupId>
+						<artifactId>xtend-maven-plugin</artifactId>
 					</plugin>
 				</plugins>
 			</build>
-
 		</profile>
 
 		<!-- Enable this profile to build the aggregated updatesite "updatesite.aggr" 

--- a/pom.xml
+++ b/pom.xml
@@ -69,24 +69,25 @@
 
 	<build>
 		<plugins>
-			<!-- Build (tycho target platform) -->
+			<!-- Tycho target platform -->
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 			</plugin>
 
-			<!-- Build (general) -->
+			<!-- Cleanup -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
+				<artifactId>maven-clean-plugin</artifactId>
 			</plugin>
+
 			<!-- Build (Xtend) -->
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 
-			<!-- Build (tycho) -->
+			<!-- Build (Tycho) -->
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-source-plugin</artifactId>
@@ -105,12 +106,6 @@
 				<extensions>true</extensions>
 			</plugin>
 
-			<!-- Cleanup -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
 			<!-- Tests -->
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
@@ -121,98 +116,7 @@
 
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>${maven-compiler.version}</version>
-				</plugin>
-
-				<!-- Creates source versions of bundles -->
-				<plugin>
-					<groupId>org.eclipse.tycho</groupId>
-					<artifactId>tycho-source-plugin</artifactId>
-					<version>${tycho.version}</version>
-					<executions>
-						<execution>
-							<id>plugin-source</id>
-							<goals>
-								<goal>plugin-source</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-
-				<!-- Creates source versions of features -->
-				<plugin>
-					<groupId>org.eclipse.tycho.extras</groupId>
-					<artifactId>tycho-source-feature-plugin</artifactId>
-					<version>${tycho.version}</version>
-					<executions>
-						<execution>
-							<id>source-feature</id>
-							<phase>package</phase>
-							<goals>
-								<goal>source-feature</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-
-				<!-- Correctly handles source features on p2 update site -->
-				<plugin>
-					<groupId>org.eclipse.tycho</groupId>
-					<artifactId>tycho-p2-plugin</artifactId>
-					<version>${tycho.version}</version>
-					<executions>
-						<execution>
-							<id>attached-p2-metadata</id>
-							<phase>package</phase>
-							<goals>
-								<goal>p2-metadata</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-
-				<plugin>
-					<groupId>org.eclipse.xtend</groupId>
-					<artifactId>xtend-maven-plugin</artifactId>
-					<version>${xtext.version}</version>
-					<executions>
-						<execution>
-							<phase>generate-sources</phase>
-							<goals>
-								<goal>compile</goal>
-							</goals>
-							<configuration>
-								<outputDirectory>xtend-gen</outputDirectory>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-clean-plugin</artifactId>
-					<version>${maven-clean.version}</version>
-					<executions>
-						<execution>
-							<id>gen-clean</id>
-							<phase>clean</phase>
-							<goals>
-								<goal>clean</goal>
-							</goals>
-							<configuration>
-								<filesets>
-									<fileset>
-										<directory>xtend-gen</directory>
-									</fileset>
-								</filesets>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-
+				<!--- Use Tycho -->
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-maven-plugin</artifactId>
@@ -220,34 +124,7 @@
 					<extensions>true</extensions>
 				</plugin>
 
-				<!-- Use Tycho compiler without project-specific settings -->
-				<plugin>
-					<groupId>org.eclipse.tycho</groupId>
-					<artifactId>tycho-compiler-plugin</artifactId>
-					<version>${tycho.version}</version>
-					<configuration>
-						<useProjectSettings>false</useProjectSettings>
-					</configuration>
-				</plugin>
-
-				<plugin>
-					<groupId>org.eclipse.tycho</groupId>
-					<artifactId>tycho-surefire-plugin</artifactId>
-					<version>${tycho.version}</version>
-					<configuration>
-						<includes>
-							<include>**/*Test.java</include>
-							<include>**/*Tests.java</include>
-							<include>**/*Test.class</include>
-							<include>**/*Tests.class</include>
-						</includes>
-						<excludes>
-							<exclude>**/Abstract*</exclude>
-						</excludes>
-						<failIfNoTests>true</failIfNoTests>
-					</configuration>
-				</plugin>
-
+				<!-- Target platform configuration -->
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>target-platform-configuration</artifactId>
@@ -274,6 +151,30 @@
 					</configuration>
 				</plugin>
 
+				<!-- Consider Xtend in cleanup -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>${maven-clean.version}</version>
+					<executions>
+						<execution>
+							<id>gen-clean</id>
+							<phase>clean</phase>
+							<goals>
+								<goal>clean</goal>
+							</goals>
+							<configuration>
+								<filesets>
+									<fileset>
+										<directory>xtend-gen</directory>
+									</fileset>
+								</filesets>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+
+				<!-- Configure exec-maven-plugin for launching MWE2 -->
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
@@ -326,6 +227,100 @@
 							<version>${xtext.version}</version>
 						</dependency>
 					</dependencies>
+				</plugin>
+
+				<!-- Use Xtend -->
+				<plugin>
+					<groupId>org.eclipse.xtend</groupId>
+					<artifactId>xtend-maven-plugin</artifactId>
+					<version>${xtext.version}</version>
+					<executions>
+						<execution>
+							<phase>generate-sources</phase>
+							<goals>
+								<goal>compile</goal>
+							</goals>
+							<configuration>
+								<outputDirectory>xtend-gen</outputDirectory>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+
+				<!-- Use Tycho compiler without project-specific settings -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-compiler-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<configuration>
+						<useProjectSettings>false</useProjectSettings>
+					</configuration>
+				</plugin>
+
+				<!-- Run tests with Tycho surefire -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<configuration>
+						<includes>
+							<include>**/*Test.java</include>
+							<include>**/*Tests.java</include>
+							<include>**/*Test.class</include>
+							<include>**/*Tests.class</include>
+						</includes>
+						<excludes>
+							<exclude>**/Abstract*</exclude>
+						</excludes>
+						<failIfNoTests>true</failIfNoTests>
+					</configuration>
+				</plugin>
+
+				<!-- Creates source versions of bundles -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-source-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<executions>
+						<execution>
+							<id>plugin-source</id>
+							<goals>
+								<goal>plugin-source</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+
+				<!-- Creates source versions of features -->
+				<plugin>
+					<groupId>org.eclipse.tycho.extras</groupId>
+					<artifactId>tycho-source-feature-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<executions>
+						<execution>
+							<id>source-feature</id>
+							<phase>package</phase>
+							<goals>
+								<goal>source-feature</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+
+				<!-- Correctly handles source features on p2 update site -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<executions>
+						<execution>
+							<id>attached-p2-metadata</id>
+							<phase>package</phase>
+							<goals>
+								<goal>p2-metadata</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.vitruv</groupId>
@@ -399,7 +398,7 @@
 				</plugins>
 			</build>
 		</profile>
-		
+
 		<!-- Runs "workflow/generate.mwe2" workflow in generate-source phase, if existing, with dependencies for Ecore
 			metamodel code generation. If further dependencies are required, e.g., for Xtext language builds, add them
 			to the plugin via pluginManagement -->
@@ -437,26 +436,26 @@
 							</execution>
 						</executions>
 						<dependencies>
-						<dependency>
-							<groupId>org.eclipse.emf</groupId>
-							<artifactId>org.eclipse.emf.mwe2.lib</artifactId>
-							<version>${mwe2.version}</version>
-						</dependency>
-						<dependency>
-							<groupId>org.eclipse.emf</groupId>
-							<artifactId>org.eclipse.emf.codegen</artifactId>
-							<version>${emf-codegen.version}</version>
-						</dependency>
-						<dependency>
-							<groupId>org.eclipse.emf</groupId>
-							<artifactId>org.eclipse.emf.codegen.ecore</artifactId>
-							<version>${ecore-codegen.version}</version>
-						</dependency>
-						<dependency>
-							<groupId>org.eclipse.emf</groupId>
-							<artifactId>org.eclipse.emf.mwe.utils</artifactId>
-							<version>${mwe.version}</version>
-						</dependency>
+							<dependency>
+								<groupId>org.eclipse.emf</groupId>
+								<artifactId>org.eclipse.emf.mwe2.lib</artifactId>
+								<version>${mwe2.version}</version>
+							</dependency>
+							<dependency>
+								<groupId>org.eclipse.emf</groupId>
+								<artifactId>org.eclipse.emf.codegen</artifactId>
+								<version>${emf-codegen.version}</version>
+							</dependency>
+							<dependency>
+								<groupId>org.eclipse.emf</groupId>
+								<artifactId>org.eclipse.emf.codegen.ecore</artifactId>
+								<version>${ecore-codegen.version}</version>
+							</dependency>
+							<dependency>
+								<groupId>org.eclipse.emf</groupId>
+								<artifactId>org.eclipse.emf.mwe.utils</artifactId>
+								<version>${mwe.version}</version>
+							</dependency>
 						</dependencies>
 					</plugin>
 


### PR DESCRIPTION
- Remove the obsolete `maven-compiler-plugin`
- Separate MWE2 workflows into cleanup and generation
- Activate MWE2 workflows by convention (workflow files at specific locations) instead of marker files with configuration properties
- Activate aggregated updatesite build by aggregation file rather than additional marker file
- Remove Eclipse updates repository