### PR TITLE
Allow Test Projects to Configure Their Test Harness With Marker Files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -571,7 +571,7 @@
 			</build>
 		</profile>
 		
-		<!-- Uses tycho-surefire instead of maven-surefire to run tests that require an Equinox platform -->
+		<!-- Uses maven-surefire instead of tycho-surefire to run tests that do not require an Equinox platform -->
 		<profile>
 			<id>standalone-test</id>
 			<activation>
@@ -614,7 +614,7 @@
 			</build>
 		</profile>
 		
-		<!-- Uses tycho-surefire instead of maven-surefire to run tests that require a full Eclipse workbench -->
+		<!-- Configure tycho-surefire to run tests is a full Eclipse workbench with UI -->
 		<profile>
 			<id>workbench-test</id>
 			<activation>
@@ -636,5 +636,4 @@
 			</build>
 		</profile>
 	</profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,7 @@
 			</build>
 		</profile>
 		
-		<!-- Configure tycho-surefire to run tests is a full Eclipse workbench with UI -->
+		<!-- Configure tycho-surefire to run tests in a full Eclipse workbench with UI -->
 		<profile>
 			<id>workbench-test</id>
 			<activation>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven-compiler.version>3.8.1</maven-compiler.version>
+		<maven-surefire.version>2.22.2</maven-surefire.version>
+		<junit-jupiter.version>5.7.0</junit-jupiter.version>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
 	</properties>
@@ -105,7 +107,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 			</plugin>
-
 		</plugins>
 
 		<pluginManagement>
@@ -215,21 +216,23 @@
 					</configuration>
 				</plugin>
 
-				<!-- Run tests with Tycho surefire -->
+				<!-- Run test with normal surefire -->
+				<plugin>
+				    <groupId>org.apache.maven.plugins</groupId>
+				    <artifactId>maven-surefire-plugin</artifactId>
+				    <version>${maven-surefire.version}</version>
+					<configuration>
+						<failIfNoTests>true</failIfNoTests>
+						<testClassesDirectory>target/classes</testClassesDirectory>
+					</configuration>
+				</plugin>
+				  
+  				<!-- Run tests with Tycho surefire -->
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-surefire-plugin</artifactId>
 					<version>${tycho.version}</version>
 					<configuration>
-						<includes>
-							<include>**/*Test.java</include>
-							<include>**/*Tests.java</include>
-							<include>**/*Test.class</include>
-							<include>**/*Tests.class</include>
-						</includes>
-						<excludes>
-							<exclude>**/Abstract*</exclude>
-						</excludes>
 						<failIfNoTests>true</failIfNoTests>
 					</configuration>
 				</plugin>
@@ -283,6 +286,16 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+	
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-engine</artifactId>
+				<version>${junit-jupiter.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<profiles>
 		<!-- Build configuration of parent POM itself -->
@@ -553,6 +566,71 @@
 								<phase>package</phase>
 							</execution>
 						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		<!-- Uses tycho-surefire instead of maven-surefire to run tests that require an Equinox platform -->
+		<profile>
+			<id>standalone-test</id>
+			<activation>
+				<file>
+					<exists>.tests-without-platform</exists>
+				</file>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter-engine</artifactId>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+			    		<groupId>org.eclipse.tycho</groupId>
+					    <artifactId>tycho-surefire-plugin</artifactId>
+					    <executions>	
+					    	<execution>
+					    		<id>default-test</id>
+					    		<phase>none</phase>
+					    	</execution>
+					    </executions>
+		 		   </plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>test</id>
+								<phase>test</phase>
+								<goals>
+									<goal>test</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		<!-- Uses tycho-surefire instead of maven-surefire to run tests that require a full Eclipse workbench -->
+		<profile>
+			<id>workbench-test</id>
+			<activation>
+				<file>
+					<exists>.tests-need-workbench</exists>
+				</file>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<configuration>
+							<useUIHarness>true</useUIHarness>
+							<useUIThread>false</useUIThread>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
Marker file | result
--- | ---
_none_ | same as previously: run in an Equinox platform, but without a workbench
`.tests-without-platform` | run with `maven-surefire`
`.tests-need-workbench | run in an Equinox platform _with_ a workbench