### PR TITLE
Tests and P2 Metadata Plugin Correction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
 					<version>${tycho.version}</version>
 					<executions>
 						<execution>
-							<id>attached-p2-metadata</id>
+							<id>attach-p2-metadata</id>
 							<phase>package</phase>
 							<goals>
 								<goal>p2-metadata</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,8 @@
 					<configuration>
 						<failIfNoTests>true</failIfNoTests>
 						<redirectTestOutputToFile>true</redirectTestOutputToFile>
-						<testClassesDirectory>target/classes</testClassesDirectory>
+						<!-- We do not (need to) mark the source folder in eclipse-test-plugins as a test source folder, so classes are compiled into the ordinary output directory -->
+						<testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
 					</configuration>
 				</plugin>
 				  


### PR DESCRIPTION
* Sets the test output directory for tests run with `maven-surefire` to the output directory defined for the project instead of a hardcoded folder
* Corrects the ID of the `tycho-p2-plugin`