### PR TITLE
GitHub Actions Verification and Deployment 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: Verify and publish to Maven Central
+on:
+  push:
+    branches: [master]
+  create:
+    tags:
+  pull_request:
+jobs:
+  verify:
+    name: Verify configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install GPG secret key
+        run: |
+          cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish to the Maven Central Repository
+        run: >
+          mvn clean verify
+          --batch-mode
+          --no-transfer-progress
+          -Dstyle.color=always
+          -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+  deploy_snapshot:
+    name: Deploy snapshot
+    runs-on: ubuntu-latest
+    needs: verify
+    if: github.ref == 'refs/heads/master' && github.repository_owner == 'vitruv-tools'
+    steps:
+      - run: >
+          mvn deploy
+          --batch-mode
+          --no-transfer-progress
+          -Dstyle.color=always
+          -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+  deploy_release:
+    name: Deploy release
+    runs-on: ubuntu-latest
+    needs: verify
+    if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
+    steps:
+      - name: Stage at the Maven Central Repository
+        run: >
+          mvn deploy -P release
+          --batch-mode
+          --no-transfer-progress
+          -Dstyle.color=always
+          -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      - name: Release at the Maven Central Repository
+        run: >
+          mvn nexus-staging:release -P release
+          --batch-mode
+          --no-transfer-progress
+          -Dstyle.color=always
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
     tags:
   pull_request:
 jobs:
-  verify:
-    name: Verify configuration
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
     steps:
       - name: Install GPG secret key
@@ -29,20 +29,16 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-      - name: Publish to the Maven Central Repository
+      - name: Verify configuration
         run: >
           mvn clean verify
           --batch-mode
           --no-transfer-progress
           -Dstyle.color=always
           -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-  deploy_snapshot:
-    name: Deploy snapshot
-    runs-on: ubuntu-latest
-    needs: verify
-    if: github.ref == 'refs/heads/master' && github.repository_owner == 'vitruv-tools'
-    steps:
-      - run: >
+      - name: Deploy snapshot
+        if: github.repository_owner == 'vitruv-tools'
+        run: >
           mvn deploy
           --batch-mode
           --no-transfer-progress
@@ -51,13 +47,8 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-  deploy_release:
-    name: Deploy release
-    runs-on: ubuntu-latest
-    needs: verify
-    if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
-    steps:
-      - name: Stage at the Maven Central Repository
+      - name: Stage release
+        if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
         run: >
           mvn deploy -P release
           --batch-mode
@@ -67,7 +58,8 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-      - name: Release at the Maven Central Repository
+      - name: Deploy release
+        if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
         run: >
           mvn nexus-staging:release -P release
           --batch-mode
@@ -76,5 +68,4 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 jobs:
   publish:
-    name: Publish
+    name: Verify and Publish
     runs-on: ubuntu-latest
     steps:
       - name: Install GPG secret key
@@ -37,7 +37,7 @@ jobs:
           -Dstyle.color=always
           -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Deploy snapshot
-        if: github.repository_owner == 'vitruv-tools'
+        if: github.ref == 'refs/heads/master' && github.repository_owner == 'vitruv-tools'
         run: >
           mvn deploy
           --batch-mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ jobs:
     name: Verify and Publish
     runs-on: ubuntu-latest
     steps:
-      - name: Install GPG secret key
-        run: |
-          cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
-          gpg --list-secret-keys --keyid-format LONG
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache
@@ -29,42 +25,41 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Verify configuration
         run: >
           mvn clean verify
           --batch-mode
           --no-transfer-progress
-          -Dstyle.color=always
-          -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+        env:
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Deploy snapshot
         if: github.ref == 'refs/heads/master' && github.repository_owner == 'vitruv-tools'
         run: >
           mvn deploy
           --batch-mode
           --no-transfer-progress
-          -Dstyle.color=always
-          -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Stage release
         if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
         run: >
           mvn deploy -P release
           --batch-mode
           --no-transfer-progress
-          -Dstyle.color=always
-          -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Deploy release
         if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
         run: >
           mvn nexus-staging:release -P release
           --batch-mode
           --no-transfer-progress
-          -Dstyle.color=always
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@ For building aggregated updatesites with the CBI aggregator, a marker file `.mav
 
 ## Deployment
 
+### Automatic
+
+Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `master` branch are deployed to the Sonatype Snapshots repository. Commits with release versions that are also tagged as a release are deployed to the Sonatype Release repository.
+
+Both the Sonatype user and the GPG key used for signing are provided by secrets of the GitHub repository.
+
+### Manual
+
 Follow the [Sonatype documentation](https://central.sonatype.org/pages/apache-maven.html) for deployment instructions.
 
-Having set up a PGP key, use `mvn clean deploy` with an appropriate Sonatype Jira user defined in your `settings.xml` to deploy a snapshot to Sonatype.
+Having set up a GPG key, use `mvn clean deploy` with an appropriate Sonatype Jira user defined in your `settings.xml` to deploy a snapshot to Sonatype.
 
 To make a release, first change the version to a release version and then run `mvn clean deploy -P release`. This stages the release on the Sonatype Nexus server. To confirm the release and start the sync to Maven Central, run `mvn nexus-staging:release -P release`.
 Alternatively, confirm the release in the staging repository at the [Sonatype Nexus repository](https://oss.sonatype.org/).

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,12 @@
 								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<gpgArguments>
+								<arg>--pinentry-mode</arg>
+								<arg>loopback</arg>
+							</gpgArguments>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
This PR adds a GitHub actions configuration that
- verifies every commit with Maven
- deploys snapshot version commits to the `master` branch to the Sonatype snapshots repository
- performs a release for release version commits that are tagged as a release to the Sonatype release repository