### PR TITLE
Release 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.vitruv</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.0</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all builds of vitruv.tools</description>
 	<url>http://vitruv.tools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.vitruv</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.2.0</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all builds of vitruv.tools</description>
 	<url>http://vitruv.tools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,14 @@
 		<junit-jupiter.version>5.7.1</junit-jupiter.version>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+		<eclipse.updatesite>http://download.eclipse.org/releases/2021-03</eclipse.updatesite>
 	</properties>
 
 	<repositories>
 		<repository>
 			<id>Eclipse</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/2021-03</url>
+			<url>${eclipse.updatesite}</url>
 		</repository>
 		<repository>
 			<id>Vitruv License</id>
@@ -517,7 +518,7 @@
 								<repository>
 									<id>Eclipse</id>
 									<layout>p2</layout>
-									<url>http://download.eclipse.org/releases/2021-03</url>
+									<url>${eclipse.updatesite}</url>
 								</repository>
 								<repository>
 									<id>Eclipse CBI Aggregator</id>


### PR DESCRIPTION
Releases POM version 1.2.0 with Eclipse dependencies increased to 2021-03.

In addition, it makes a minor improvement to the `pom.xml` by putting the Eclipse updatesite into a property to be defined at a single place.