### PR TITLE
Eclipse 2021-12

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ In addition, some needs to be run in a full Eclipse workbench, i.e., with UI har
 
 For building aggregated updatesites with the CBI aggregator, the aggregator file named `updatesite.aggr` has to be placed within the project's main folder to enable building the updatesite.
 
+### MWE2 Workflows
+
+The POM preconfigures the automatic execution of MWE2 workflow executions placed in projects under `workflow/clean.mwe2` for cleanup purposes and under `workflow/generate.mwe2` for generation purposes. The Maven build automatically replaces the variable `workspaceRoot` with the proper path to the workspace root during the build process. So every `mwe2` file should use that variable to define the workspace root for execution within Eclipse (usually relative to the project folder) to be then automatically adjusted during a Maven build.
+
 ## Deployment
 
 ### Automatic

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<repository>
 			<id>Vitruv License</id>
 			<layout>p2</layout>
-			<url>http://vitruv-tools.github.io/updatesite/release/license</url>
+			<url>https://vitruv-tools.github.io/updatesite/release/license</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
 									<arguments>
 										<argument>/${project.basedir}/workflow/clean.mwe2</argument>
 										<argument>-p</argument>
-										<argument>rootPath=/${project.basedir}/..</argument>
+										<argument>workspaceRoot=${maven.multiModuleProjectDirectory}</argument>
 									</arguments>
 									<classpathScope>compile</classpathScope>
 									<includePluginDependencies>true</includePluginDependencies>
@@ -437,7 +437,7 @@
 									<arguments>
 										<argument>/${project.basedir}/workflow/generate.mwe2</argument>
 										<argument>-p</argument>
-										<argument>rootPath=/${project.basedir}/..</argument>
+										<argument>workspaceRoot=${maven.multiModuleProjectDirectory}</argument>
 									</arguments>
 									<classpathScope>compile</classpathScope>
 									<includePluginDependencies>true</includePluginDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<junit-jupiter.version>5.7.1</junit-jupiter.version>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
-		<eclipse.updatesite>http://download.eclipse.org/releases/2021-06</eclipse.updatesite>
+		<eclipse.updatesite>https://download.eclipse.org/releases/2021-12</eclipse.updatesite>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven-compiler.version>3.8.1</maven-compiler.version>
 		<maven-surefire.version>2.22.2</maven-surefire.version>
-		<junit-jupiter.version>5.7.1</junit-jupiter.version>
+		<junit-jupiter.version>5.8.2</junit-jupiter.version>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
 		<eclipse.updatesite>https://download.eclipse.org/releases/2021-12</eclipse.updatesite>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<properties>
 		<mwe.version>1.6.1</mwe.version>
 		<mwe2.version>2.12.1</mwe2.version>
-		<tycho.version>2.3.0</tycho.version>
+		<tycho.version>2.5.0</tycho.version>
 		<xtext.version>2.25.0</xtext.version>
 		<emf-codegen.version>2.22.0</emf-codegen.version>
 		<ecore-codegen.version>2.26.0</ecore-codegen.version>
@@ -219,7 +219,6 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven-surefire.version}</version>
 					<configuration>
-						<failIfNoTests>true</failIfNoTests>
 						<redirectTestOutputToFile>true</redirectTestOutputToFile>
 						<!-- We do not (need to) mark the source folder in eclipse-test-plugins as a test source folder, so classes are compiled into the ordinary output directory -->
 						<testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>


### PR DESCRIPTION
Several upgrades in relation to moving to Eclipse 2021-12:
* Change updatesites from http to https
* Change Eclipse updatesite to 2021-12
* Upgrade to Tycho 2.5.0, JUnit 5.8.2
* Add functionality for automatic adjustment of workspace paths within MWE2 workflow to be executable in both Eclipse and the Maven build