### PR TITLE
Release 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.vitruv</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.4.0</version>
+	<version>1.5.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all builds of vitruv.tools</description>
 	<url>http://vitruv.tools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.vitruv</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.4.0-SNAPSHOT</version>
+	<version>1.4.0</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all builds of vitruv.tools</description>
 	<url>http://vitruv.tools</url>


### PR DESCRIPTION
Releases POM version 1.4.0 with Eclipse dependencies increased to 2021-12.

In addition, it improves the Tycho and JUnit versions, switches from http to https updatesites, enables full stack traces in tests, and adapts and documents automatic adjustment of paths in MWE2 executions.