### PR TITLE
Fix Workbench Tests on macOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
 		<eclipse.updatesite>https://download.eclipse.org/releases/2021-12</eclipse.updatesite>
+		<macos-jvm-swt-flags/> <!-- flag for SWT workaround on macOS -->
 	</properties>
 
 	<repositories>
@@ -673,10 +674,24 @@
 						<configuration>
 							<useUIHarness>true</useUIHarness>
 							<useUIThread>false</useUIThread>
+							<argLine>${macos-jvm-swt-flags}</argLine>
 						</configuration>
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+
+		<!-- macOS requires UI work to be executed on the main thread only -->
+		<profile>
+			<id>macos-jvm-swt-flags</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<macos-jvm-swt-flags>-XstartOnFirstThread</macos-jvm-swt-flags>
+			</properties>
 		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
This PR adds a fix for workbench tests when run on macOS.
Relates to [Vitruv#521](https://github.com/vitruv-tools/Vitruv/issues/521) and fixes the issues for x86-64 Macs (see https://github.com/vitruv-tools/Vitruv/runs/6777146382)

As a follow-up to this PR, we should release a new version and update the dependencies in all Vitruv repositories such that the Maven build succeeds on macOS. Here we should decide to include only this fix as version `1.4.1` or also include the spotless PR as version `1.5.0`. Excluding spotless would probably be the cleaner solution but require GIT history rewrite.