### PR TITLE
Deploy release versions after creating a GitHub Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: Verify and publish to Maven Central
 on:
   push:
     branches: [master]
-  create:
-    tags:
+  release:
+    types: [created]
   pull_request:
 jobs:
   publish:
@@ -45,7 +45,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Stage release
-        if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
+        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'
         run: >
           mvn deploy -P release
           --batch-mode
@@ -55,7 +55,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Deploy release
-        if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
+        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'
         run: >
           mvn nexus-staging:release -P release
           --batch-mode

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The POM preconfigures the automatic execution of MWE2 workflow executions placed
 
 ### Automatic
 
-Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `master` branch are deployed to the Sonatype Snapshots repository. Commits with release versions that are also tagged as a release are deployed to the Sonatype Release repository.
+Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `master` branch are deployed to the Sonatype Snapshots repository. For release versions, the according commit should be tagged with the version number and a [GitHub release](https://github.com/vitruv-tools/Maven-Build-Parent/releases) should be created which will get deployed to the Sonatype Release repository.
 
 Both the Sonatype user and the GPG key used for signing are provided by secrets of the GitHub repository.
 


### PR DESCRIPTION
This PR changes the release deployment behaviour to rely on GitHub Releases instead of on Git tags. In particular, a release version is only deployed after a GitHub release is created.

It would be beneficial to also test that the trigger correctly works for Releases. Following GitHub documentation, Release can be deleted again, thus we could create a test release for this purpose. However, this would require actually pushing something to Maven Central. Open for suggestions how to circumvent this and still being able to test the workflow.