### PR TITLE
Rename branch `master` to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Verify and publish to Maven Central
 on:
   push:
-    branches: [master]
+    branches: [main]
   release:
     types: [created]
   pull_request:
@@ -35,7 +35,7 @@ jobs:
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Deploy snapshot
-        if: github.ref == 'refs/heads/master' && github.repository_owner == 'vitruv-tools'
+        if: github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools'
         run: >
           mvn deploy
           --batch-mode

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The POM preconfigures the automatic execution of MWE2 workflow executions placed
 
 ### Automatic
 
-Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `master` branch are deployed to the Sonatype Snapshots repository. For release versions, the according commit should be tagged with the version number and a [GitHub release](https://github.com/vitruv-tools/Maven-Build-Parent/releases) should be created which will get deployed to the Sonatype Release repository.
+Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `main` branch are deployed to the Sonatype Snapshots repository. For release versions, the according commit should be tagged with the version number and a [GitHub release](https://github.com/vitruv-tools/Maven-Build-Parent/releases) should be created which will get deployed to the Sonatype Release repository.
 
 Both the Sonatype user and the GPG key used for signing are provided by secrets of the GitHub repository.
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 	<scm>
 		<connection>scm:git:git://github.com/vitruv-tools/Maven-Build-Parent.git</connection>
 		<developerConnection>scm:git:ssh://github.com/vitruv-tools/Maven-Build-Parent.git</developerConnection>
-		<url>http://github.com/vitruv-tools/Maven-Build-Parent/tree/master</url>
+		<url>http://github.com/vitruv-tools/Maven-Build-Parent/tree/main</url>
 	</scm>
 
 	<properties>


### PR DESCRIPTION
This PR prepares the repository for renaming the default branch from `master` to `main`.
This follows general naming conventions adopted by major GIT hosters and is already done in the recently created Vitruv repositories (DSLs / Change / Aggregated-Update-Site).

GitHub provides [built-in functionality](https://github.com/github/renaming#renaming-existing-branches) for renaming the branch. This PR adjusts the CI actions, build artifacts, and the Readme. Thus, first the branch has to be renamed, then the PR should be merged.
As we use static versions of the build parent in all Vitruv repositories, this change should not have any effect on other repositories.