### PR TITLE
Prepare CI for new branch management regarding releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/major.yaml
+++ b/.github/PULL_REQUEST_TEMPLATE/major.yaml
@@ -1,0 +1,9 @@
+name: Major Update
+description: Contribution requires a new major version release
+labels: "major"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Pull requests regarding major updates need to target the `develop` branch.
+        Please make sure to select the appropriate branch while creating the pull request.

--- a/.github/PULL_REQUEST_TEMPLATE/minor.yaml
+++ b/.github/PULL_REQUEST_TEMPLATE/minor.yaml
@@ -1,0 +1,9 @@
+name: Minor Update
+description: Contribution requires a new minor version release
+labels: "minor"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Pull requests regarding minor updates need to target the `main` branch.
+        Please make sure to select the appropriate branch while creating the pull request.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Verify and publish to Maven Central
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   release:
     types: [created]
   pull_request:
@@ -35,7 +35,7 @@ jobs:
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Deploy snapshot
-        if: github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools'
+        if: github.ref == 'refs/heads/develop' && github.repository_owner == 'vitruv-tools'
         run: >
           mvn deploy
           --batch-mode

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The POM preconfigures the automatic execution of MWE2 workflow executions placed
 
 ### Automatic
 
-Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `develop` branch are deployed to the Sonatype Snapshots repository. For release versions, the according commit should be tagged with the version number and a [GitHub release](https://github.com/vitruv-tools/Maven-Build-Parent/releases) should be created which will get deployed to the Sonatype Release repository.
+Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `develop` branch are deployed to the Sonatype Snapshots repository. For release versions, the according commit on the `main` branch has to be tagged with the version number and a [GitHub release](https://github.com/vitruv-tools/Maven-Build-Parent/releases) has to be created, which triggers deployment to the Sonatype Release repository.
 
 Both the Sonatype user and the GPG key used for signing are provided by secrets of the GitHub repository.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The POM preconfigures the automatic execution of MWE2 workflow executions placed
 
 ### Automatic
 
-Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `main` branch are deployed to the Sonatype Snapshots repository. For release versions, the according commit should be tagged with the version number and a [GitHub release](https://github.com/vitruv-tools/Maven-Build-Parent/releases) should be created which will get deployed to the Sonatype Release repository.
+Deployment is automatically performed by GitHub Actions. Snapshot versions committed to the `develop` branch are deployed to the Sonatype Snapshots repository. For release versions, the according commit should be tagged with the version number and a [GitHub release](https://github.com/vitruv-tools/Maven-Build-Parent/releases) should be created which will get deployed to the Sonatype Release repository.
 
 Both the Sonatype user and the GPG key used for signing are provided by secrets of the GitHub repository.
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 	<scm>
 		<connection>scm:git:git://github.com/vitruv-tools/Maven-Build-Parent.git</connection>
 		<developerConnection>scm:git:ssh://github.com/vitruv-tools/Maven-Build-Parent.git</developerConnection>
-		<url>http://github.com/vitruv-tools/Maven-Build-Parent/tree/main</url>
+		<url>https://github.com/vitruv-tools/Maven-Build-Parent</url>
 	</scm>
 
 	<properties>


### PR DESCRIPTION
As discussed in a recent developers meeting, we will change the current branch structure of one `main` branch into which all changes are merged. The main motivation for this is the complexity when trying to add a minor release while already changes for a major release were deployed to `main`.

The new branching approach will use the two primary branches `main` and `develop`. `develop` contains major releases which are not released immediately. Snapshot builds are thus created on the `develop` branch. Any release must be based on the `main` branch.
This adjustment will require developers to select the appropriate branch to merge into when creating pull requests. Minor changes shall immediately be merged into `main`, major changes into `develop`.
Maybe GitHub even provides some functionality to either require `major` / `minor` labels for any PR or select the appropriate merging branch based on the label selection.

Steps to migrate to new branch management
1) Merge this PR
2) Rename the current `main` to `develop`
3) Rename the current `new-main` (pointing to v.1.4.1) to `main`
4) Update branch protection rules to cover `main` and `develop`