### PR TITLE
Set generic developer based on mailing list as correspondence in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,10 @@
 
 	<developers>
 		<developer>
-			<name>Heiko Klare</name>
-			<email>heiko.klare@kit.edu</email>
+			<name>Vitruvius Developers</name>
+			<email>vitruv-dev@lists.kit.edu</email>
 			<organization>Karlsruhe Institute of Technology (KIT), Germany</organization>
-			<organizationUrl>http://kit.edu</organizationUrl>
+			<organizationUrl>https://kit.edu</organizationUrl>
 		</developer>
 	</developers>
 


### PR DESCRIPTION
Replaces the developer entry in the POM with a generic developer based on a mailing list.