### PR TITLE
Correct update names regarding semantic versioning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 <!--
-Pull requests regarding major updates need to target the `develop` branch.
-Pull requests regarding minor updates need to target the `main` branch.
+Pull requests regarding major or minor updates need to target the `develop` branch.
+Pull requests regarding patch updates need to target the `main` branch.
 Please make sure to select the appropriate branch while creating the pull request.
-Please also make sure to add an appropriate label (`major` / `minor`).
+Please also make sure to add an appropriate label (`major` / `minor` / `patch`).
+For a reference on semantic versioning, see https://semver.org.
 -->


### PR DESCRIPTION
Fixes some misconception regarding semantic versioning in the PR template description.

Now the branching behaviour is described as follows:
- Major (x.\_.\_) -> develop
- Minor (\_.x.\_) -> develop
- Patch (\_.\_.x) -> main