### PR TITLE
Migrate to Java 17 CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD


### PR DESCRIPTION
In preparation for migrating to Java 17, this PR already updates the CI to use Java 17 for building in source compatibility mode for Java 11 (as specified in [Maven Build Parent](https://github.com/vitruv-tools/Maven-Build-Parent)).

Additionally, the Java distribution is changed to the Eclipse distribution temurin.