### PR TITLE
Skip gpg signing for verifying the configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Verify configuration
         run: >
           mvn clean verify
+          -Dgpg.skip
           --batch-mode
           --no-transfer-progress
         env:


### PR DESCRIPTION
Currently, PRs from external contributors will fail (like the DependaBot PRs) as the configuration verification requires the secret GPG key. Thus, this PR disables GPG signing for verification builds. Any release-related job still uses GPG signing.