### PR TITLE
Eclipse 2022-12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,7 @@
 		<tycho.version>3.0.0</tycho.version> <!-- https://search.maven.org/artifact/org.eclipse.tycho/tycho-maven-plugin -->
 		<xtext.version>2.29.0</xtext.version> <!-- https://search.maven.org/artifact/org.eclipse.xtext/org.eclipse.xtext.common.types -->
 		<macos-jvm-swt-flags/> <!-- flag for SWT workaround on macOS -->
-		<maven.compiler.target>17</maven.compiler.target>
-		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.release>17</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -34,23 +34,24 @@
 	</scm>
 
 	<properties>
-		<eclipse.updatesite>https://download.eclipse.org/releases/2022-06</eclipse.updatesite>
+		<eclipse.version>2022-12</eclipse.version>
+		<eclipse.updatesite>https://download.eclipse.org/releases/${eclipse.version}</eclipse.updatesite>
 		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version> <!-- https://search.maven.org/artifact/org.codehaus.mojo/exec-maven-plugin/ -->
-		<junit-jupiter.version>5.8.1</junit-jupiter.version> <!-- https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter -->
+		<junit-jupiter.version>5.9.1</junit-jupiter.version> <!-- https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter -->
 		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version> <!-- https://search.maven.org/artifact/org.apache.maven.plugins/maven-clean-plugin -->
 		<maven-compiler.version>3.10.1</maven-compiler.version> <!-- https://search.maven.org/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
 		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version> <!-- https://search.maven.org/artifact/org.apache.maven.plugins/maven-gpg-plugin -->
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version> <!-- https://search.maven.org/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
 		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version> <!-- https://search.maven.org/artifact/org.sonatype.plugins/nexus-staging-maven-plugin -->
 		<org.eclipse.emf.codegen.version>2.22.0</org.eclipse.emf.codegen.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.codegen -->
-		<org.eclipse.emf.codegen.ecore.version>2.30.0</org.eclipse.emf.codegen.ecore.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.codegen.ecore -->
-		<org.eclipse.emf.mwe.utils.version>1.7.0</org.eclipse.emf.mwe.utils.version><!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.mwe.utils -->
-		<org.eclipse.emf.mwe2.version>2.13.0</org.eclipse.emf.mwe2.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.mwe2.lib -->
-		<tycho.version>2.7.4</tycho.version> <!-- https://search.maven.org/artifact/org.eclipse.tycho/tycho-maven-plugin -->
-		<xtext.version>2.27.0</xtext.version> <!-- https://search.maven.org/artifact/org.eclipse.xtext/org.eclipse.xtext.common.types -->
+		<org.eclipse.emf.codegen.ecore.version>2.32.0</org.eclipse.emf.codegen.ecore.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.codegen.ecore -->
+		<org.eclipse.emf.mwe.utils.version>1.8.0</org.eclipse.emf.mwe.utils.version><!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.mwe.utils -->
+		<org.eclipse.emf.mwe2.version>2.14.0</org.eclipse.emf.mwe2.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.mwe2.lib -->
+		<tycho.version>3.0.0</tycho.version> <!-- https://search.maven.org/artifact/org.eclipse.tycho/tycho-maven-plugin -->
+		<xtext.version>2.29.0</xtext.version> <!-- https://search.maven.org/artifact/org.eclipse.xtext/org.eclipse.xtext.common.types -->
 		<macos-jvm-swt-flags/> <!-- flag for SWT workaround on macOS -->
-		<maven.compiler.target>11</maven.compiler.target>
-		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -60,6 +61,11 @@
 			<id>Eclipse</id>
 			<layout>p2</layout>
 			<url>${eclipse.updatesite}</url>
+		</repository>
+		<repository>
+			<id>Eclipse Plug-Ins</id>
+			<layout>p2</layout>
+			<url>https://download.eclipse.org/tools/orbit/downloads/${eclipse.version}</url>
 		</repository>
 		<repository>
 			<id>Vitruv License</id>


### PR DESCRIPTION
- Updates the Eclipse version to 2022-12
- Updates Java to Java 17
- Updates dependencies
- Added the Eclipse Orbit Update Site as some dependencies (like Junit Jupiter) are not shipped by default with the Eclipse distribution anymore.

After this PR I would suggest to release a new version such that we can migrate all depending projects to Java 17 (which I already prepared). There is one API-breaking change coming from the minor increment of the Junit Jupiter version (thus with correct semantic versioning it must not exist) but from our own API there is nothing API-breaking. Thus, I would suggest version **2.1.0** instead of **3.0.0**. Opinions?