### PR TITLE
Add support for Maven 3.9.1 and Eclipse 2023-03

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 	</scm>
 
 	<properties>
-		<eclipse.version>2022-12</eclipse.version>
+		<eclipse.version>2023-03</eclipse.version>
 		<eclipse.updatesite>https://download.eclipse.org/releases/${eclipse.version}</eclipse.updatesite>
 		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version> <!-- https://central.sonatype.com/artifact/org.codehaus.mojo/exec-maven-plugin/3.1.0 -->
 		<junit-jupiter.version>5.9.2</junit-jupiter.version> <!-- https://central.sonatype.com/artifact/org.junit.jupiter/junit-jupiter/5.9.2 -->

--- a/pom.xml
+++ b/pom.xml
@@ -36,19 +36,19 @@
 	<properties>
 		<eclipse.version>2022-12</eclipse.version>
 		<eclipse.updatesite>https://download.eclipse.org/releases/${eclipse.version}</eclipse.updatesite>
-		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version> <!-- https://search.maven.org/artifact/org.codehaus.mojo/exec-maven-plugin -->
-		<junit-jupiter.version>5.9.1</junit-jupiter.version> <!-- https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter -->
-		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version> <!-- https://search.maven.org/artifact/org.apache.maven.plugins/maven-clean-plugin -->
-		<maven-compiler.version>3.10.1</maven-compiler.version> <!-- https://search.maven.org/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
-		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version> <!-- https://search.maven.org/artifact/org.apache.maven.plugins/maven-gpg-plugin -->
-		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version> <!-- https://search.maven.org/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
-		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version> <!-- https://search.maven.org/artifact/org.sonatype.plugins/nexus-staging-maven-plugin -->
-		<org.eclipse.emf.codegen.version>2.22.0</org.eclipse.emf.codegen.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.codegen -->
-		<org.eclipse.emf.codegen.ecore.version>2.32.0</org.eclipse.emf.codegen.ecore.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.codegen.ecore -->
-		<org.eclipse.emf.mwe.utils.version>1.8.0</org.eclipse.emf.mwe.utils.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.mwe.utils -->
-		<org.eclipse.emf.mwe2.version>2.14.0</org.eclipse.emf.mwe2.version> <!-- https://search.maven.org/artifact/org.eclipse.emf/org.eclipse.emf.mwe2.lib -->
-		<tycho.version>3.0.1</tycho.version> <!-- https://search.maven.org/artifact/org.eclipse.tycho/tycho-maven-plugin -->
-		<xtext.version>2.29.0</xtext.version> <!-- https://search.maven.org/artifact/org.eclipse.xtext/org.eclipse.xtext.common.types -->
+		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version> <!-- https://central.sonatype.com/artifact/org.codehaus.mojo/exec-maven-plugin/3.1.0 -->
+		<junit-jupiter.version>5.9.2</junit-jupiter.version> <!-- https://central.sonatype.com/artifact/org.junit.jupiter/junit-jupiter/5.9.2 -->
+		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-clean-plugin/3.2.0 -->
+		<maven-compiler.version>3.11.0</maven-compiler.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-compiler-plugin/3.11.0 -->
+		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-gpg-plugin/3.0.1 -->
+		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-surefire-plugin/2.22.2 -->
+		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version> <!-- https://central.sonatype.com/artifact/org.sonatype.plugins/nexus-staging-maven-plugin/1.6.13 -->
+		<org.eclipse.emf.codegen.version>2.23.0</org.eclipse.emf.codegen.version> <!-- https://central.sonatype.com/artifact/org.eclipse.emf/org.eclipse.emf.codegen/2.23.0 -->
+		<org.eclipse.emf.codegen.ecore.version>2.33.0</org.eclipse.emf.codegen.ecore.version> <!-- https://central.sonatype.com/artifact/org.eclipse.emf/org.eclipse.emf.codegen.ecore/2.33.0 -->
+		<org.eclipse.emf.mwe.utils.version>1.8.0</org.eclipse.emf.mwe.utils.version> <!-- https://central.sonatype.com/artifact/org.eclipse.emf/org.eclipse.emf.mwe.utils/1.8.0 -->
+		<org.eclipse.emf.mwe2.version>2.14.0</org.eclipse.emf.mwe2.version> <!-- https://central.sonatype.com/artifact/org.eclipse.emf/org.eclipse.emf.mwe2.lib/2.14.0 -->
+		<tycho.version>3.0.3</tycho.version> <!-- https://central.sonatype.com/artifact/org.eclipse.tycho/tycho-maven-plugin/3.0.3 -->
+		<xtext.version>2.30.0</xtext.version> <!-- https://central.sonatype.com/artifact/org.eclipse.xtext/org.eclipse.xtext.common.types/2.30.0 -->
 		<sdq.commons.version>2.1.0</sdq.commons.version> <!-- https://github.com/kit-sdq/SDQ-Commons -->
 		<sdq.xannotations.version>1.6.0</sdq.xannotations.version> <!-- https://github.com/kit-sdq/XAnnotations -->
 		<sdq.demometamodels.version>1.7.0</sdq.demometamodels.version> <!-- https://github.com/kit-sdq/DemoMetamodels -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.vitruv</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.1.1</version>
+	<version>2.1.2</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all builds of vitruv.tools</description>
 	<url>http://vitruv.tools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,13 @@
 		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-clean-plugin/3.2.0 -->
 		<maven-compiler.version>3.11.0</maven-compiler.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-compiler-plugin/3.11.0 -->
 		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-gpg-plugin/3.0.1 -->
-		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-surefire-plugin/2.22.2 -->
+		<maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version> <!-- https://central.sonatype.com/artifact/org.apache.maven.plugins/maven-surefire-plugin/3.0.0 -->
 		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version> <!-- https://central.sonatype.com/artifact/org.sonatype.plugins/nexus-staging-maven-plugin/1.6.13 -->
 		<org.eclipse.emf.codegen.version>2.23.0</org.eclipse.emf.codegen.version> <!-- https://central.sonatype.com/artifact/org.eclipse.emf/org.eclipse.emf.codegen/2.23.0 -->
 		<org.eclipse.emf.codegen.ecore.version>2.33.0</org.eclipse.emf.codegen.ecore.version> <!-- https://central.sonatype.com/artifact/org.eclipse.emf/org.eclipse.emf.codegen.ecore/2.33.0 -->
 		<org.eclipse.emf.mwe.utils.version>1.8.0</org.eclipse.emf.mwe.utils.version> <!-- https://central.sonatype.com/artifact/org.eclipse.emf/org.eclipse.emf.mwe.utils/1.8.0 -->
 		<org.eclipse.emf.mwe2.version>2.14.0</org.eclipse.emf.mwe2.version> <!-- https://central.sonatype.com/artifact/org.eclipse.emf/org.eclipse.emf.mwe2.lib/2.14.0 -->
-		<tycho.version>3.0.3</tycho.version> <!-- https://central.sonatype.com/artifact/org.eclipse.tycho/tycho-maven-plugin/3.0.3 -->
+		<tycho.version>3.0.4</tycho.version> <!-- https://central.sonatype.com/artifact/org.eclipse.tycho/tycho-maven-plugin/3.0.4 -->
 		<xtext.version>2.30.0</xtext.version> <!-- https://central.sonatype.com/artifact/org.eclipse.xtext/org.eclipse.xtext.common.types/2.30.0 -->
 		<sdq.commons.version>2.1.0</sdq.commons.version> <!-- https://github.com/kit-sdq/SDQ-Commons -->
 		<sdq.xannotations.version>1.6.0</sdq.xannotations.version> <!-- https://github.com/kit-sdq/XAnnotations -->


### PR DESCRIPTION
Updates the dependencies such that Maven 3.9.0 can be supported.
Updates Eclipse to 2023-03. 

Updates the version number to 2.1.2

Fixes #62 