### PR TITLE
remove p2 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,14 +96,6 @@
           <version>3.4.0</version>
         </plugin>
 
-        <!-- allow Eclipse update sites as repositories -->
-        <plugin>
-          <groupId>org.openntf.maven</groupId>
-          <artifactId>p2-layout-resolver</artifactId>
-          <version>1.9.0</version>
-          <extensions>true</extensions>
-        </plugin>
-
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
@@ -565,21 +557,11 @@
   </repositories>
 
   <pluginRepositories>
-    <!-- Maven Central should have priority over OpenNTF Artifactory -->
+    <!-- Maven Central should have priority -->
     <pluginRepository>
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo1.maven.org/maven2/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-
-    <!-- required for the p2-layout-resolver plugin -->
-    <pluginRepository>
-      <id>artifactory.openntf.org</id>
-      <name>artifactory.openntf.org</name>
-      <url>https://artifactory.openntf.org/openntf</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <!-- default value, actual value is set by profiles depending on OS -->
+    <swt.platform />
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,56 @@
           <version>3.4.2</version>
         </plugin>
 
+        <!-- used for creating wrapper modules including dependencies from external repositories -->
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.6.0</version>
+          <executions>
+            <execution>
+              <id>flatten</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>flatten</goal>
+              </goals>
+              <configuration>
+                <flattenMode>oss</flattenMode>
+                <pomElements>
+                  <repositories>remove</repositories>
+                  <build>remove</build>
+                </pomElements>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <!-- used for creating wrapper modules including dependencies from external repositories -->
+        <plugin>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.6.0</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <createDependencyReducedPom>true</createDependencyReducedPom>
+                <useDependencyReducedPomInJar>true</useDependencyReducedPomInJar>
+                <createSourcesJar>true</createSourcesJar>
+                <filters>
+                  <filter>
+                    <artifact>tools.vitruv:*</artifact>
+                    <excludes>
+                      <exclude>META-INF/MANIFEST.MF</exclude>
+                    </excludes>
+                  </filter>
+                </filters>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.3.1</version>

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,18 @@ Currently the parent POM in this project specifies Java 17 as source/target comp
 </archive>
 ```
 
+### `org.codehaus.mojo:flatten-maven-plugin`
+
+- replaces the POM of a project with an effective, flattened POM
+- configured to remove references to external repositories
+- can be used for dependency wrapper modules
+
+### `maven-shade-plugin`
+
+- includes dependencies in the built jar archive
+- removes references to dependencies from the POM in the built jar archive
+- can be used for dependency wrapper modules
+
 ### `maven-gpg-plugin`
 
 - signs generated jar archives for deployment

--- a/readme.md
+++ b/readme.md
@@ -44,24 +44,6 @@ Currently the parent POM in this project specifies Java 17 as source/target comp
 
 ## Provided Plugins
 
-### `org.openntf.maven:p2-layout-resolver`
-
-- required for adding Eclipse update sites as repositories
-- update sites are specified as follows:
-
-```
-<repository>
-    <id>some-id</id>
-    <name>Some Name</name>
-    <layout>p2</layout>
-    <url>http://abc.xyz/org/example/com/releases/${repo.some-id.version}</url>
-</repository>
-```
-
-- replace placeholders, such as `some-id`, `Some Name` and the URL, with reasonable values
-- it is good practice to store the update site version (if applicable) in a Maven property called `repo.id.version` where `id` is the id of the update site
-- to include a dependency from an added update site, use the update site id as `groupId` of the dependency
-
 ### `org.codehaus.mojo:build-helper-maven-plugin`
 
 - required for adding code in non-Java languages (such as Xtend), as well as generated code (for Xtend and Ecore) to the classpath
@@ -225,13 +207,6 @@ It is important not to use the name `add-source` as the `id` of the execution, a
 
 To generate code from the DSL code, the used DSL packages need to be included as a dependencies of the `xtext-maven-plugin` plugin.
 If the DSL code references meta-models from foreign packages, these need to be included as dependencies for the build plugin as well.
-Note that dependencies from p2 repositories, included with the `p2-layout-resolver`, cannot be used as build plugin dependencies.
-One workaround is to create a wrapper Maven module with the p2 dependencies and no content otherwise.
-Note that the packaging of the wrapper module still needs to be `jar`.
-
-The [EMF-Template] project contains a module [imports](https://github.com/vitruv-tools/EMF-Template/tree/7ba1d2a49971e56cdf9e9cac3a5373c70db16777/imports) where this is shown for an example DSL allowing (only) meta-model imports.
-To import the `persons` meta-model from a p2 updatesite dependency in [line 2](https://github.com/vitruv-tools/EMF-Template/blob/7ba1d2a49971e56cdf9e9cac3a5373c70db16777/imports/demo/src/main/importslanguage/example.imports#L2) of the file `example.imports`, an additional module `dependencywrapper` is added and included as dependency.
-The p2 dependencies are then included in the [POM](https://github.com/vitruv-tools/EMF-Template/blob/7ba1d2a49971e56cdf9e9cac3a5373c70db16777/imports/dependencywrapper/pom.xml) of the dependency wrapper module.
 
 Below you find an example configuration of the build plugin for the Reactions language.
 


### PR DESCRIPTION
p2 dependencies should be defined in the individual modules and re-packaged to be included in the deployed JARs, such that users do not need to support p2 repositories

see https://github.com/vitruv-tools/Vitruv-Change/pull/133, https://github.com/vitruv-tools/Vitruv-DSLs/pull/164, https://github.com/vitruv-tools/Vitruv/pull/662, https://github.com/vitruv-tools/Methodologist-Template/pull/4, and https://github.com/vitruv-tools/EMF-Template/pull/3