### PR TITLE
Add manifest to build resources to detect meta-models in non-JAR directories on the classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,29 +65,6 @@
   </properties>
 
   <build>
-    <resources>
-      <!-- add Ecore files to build artifact -->
-      <resource>
-        <directory>${project.basedir}</directory>
-        <includes>
-          <include>src/main/ecore/**/*</include>
-          <include>target/generated-sources/xtext-ecore/**/*</include>
-          <include>plugin.properties</include>
-          <include>plugin.xml</include>
-        </includes>
-      </resource>
-      <!-- add Xtext files to build artifact -->
-      <resource>
-        <directory>${project.build.directory}/generated-sources/xtext-java</directory>
-        <includes>
-          <include>**/*.xtextbin</include>
-          <include>**/*.xmi</include>
-          <include>**/*.g</include>
-          <include>**/*.tokens</include>
-        </includes>
-      </resource>
-    </resources>
-
     <pluginManagement>
       <plugins>
         <!-- delete `target` folder where all (also intermediate) build results are placed -->
@@ -276,6 +253,40 @@
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.3.1</version>
+          <executions>
+            <execution>
+              <id>copy-resources</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                <resources>
+                  <!-- add Ecore files to build artifact -->
+                  <resource>
+                    <directory>${project.basedir}</directory>
+                    <includes>
+                      <include>src/main/ecore/**/*</include>
+                      <include>target/generated-sources/xtext-ecore/**/*</include>
+                      <include>plugin.properties</include>
+                      <include>plugin.xml</include>
+                    </includes>
+                  </resource>
+                  <!-- add Xtext files to build artifact -->
+                  <resource>
+                    <directory>${project.build.directory}/generated-sources/xtext-java</directory>
+                    <includes>
+                      <include>**/*.xtextbin</include>
+                      <include>**/*.xmi</include>
+                      <include>**/*.g</include>
+                      <include>**/*.tokens</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,7 @@
                   <resource>
                     <directory>${project.basedir}</directory>
                     <includes>
+                      <include>META-INF/MANIFEST.MF</include>
                       <include>src/main/ecore/**/*</include>
                       <include>target/generated-sources/xtext-ecore/**/*</include>
                       <include>plugin.properties</include>


### PR DESCRIPTION
fixes #127 