### PR TITLE
Update EMF, Xtext, Xtend dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,33 +162,38 @@
           <dependencies>
             <dependency>
               <groupId>org.eclipse.emf</groupId>
+              <artifactId>org.eclipse.emf.common</artifactId>
+              <version>2.42.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.eclipse.emf</groupId>
               <artifactId>org.eclipse.emf.codegen.ecore</artifactId>
-              <version>2.41.0</version>
+              <version>2.42.0</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.emf</groupId>
               <artifactId>org.eclipse.emf.mwe.utils</artifactId>
-              <version>1.15.0</version>
+              <version>1.16.0</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.emf</groupId>
               <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-              <version>2.21.0</version>
+              <version>2.22.0</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.emf</groupId>
               <artifactId>org.eclipse.emf.mwe2.lib</artifactId>
-              <version>2.21.0</version>
+              <version>2.22.0</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.xtext</groupId>
               <artifactId>org.eclipse.xtext.common.types</artifactId>
-              <version>2.38.0</version>
+              <version>2.39.0</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.xtext</groupId>
               <artifactId>org.eclipse.xtext.xtext.generator</artifactId>
-              <version>2.38.0</version>
+              <version>2.39.0</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -198,7 +203,7 @@
           processed by the xtext-maven-plugin as well -->
           <groupId>org.eclipse.xtext</groupId>
           <artifactId>xtext-maven-plugin</artifactId>
-          <version>2.38.0</version>
+          <version>2.39.0</version>
           <executions>
             <!-- generate Java code from Vitruvius DSL code -->
             <execution>
@@ -213,7 +218,7 @@
             <dependency>
               <groupId>org.eclipse.xtend</groupId>
               <artifactId>org.eclipse.xtend.core</artifactId>
-              <version>2.38.0</version>
+              <version>2.39.0</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -221,7 +226,7 @@
         <plugin>
           <groupId>org.eclipse.xtend</groupId>
           <artifactId>xtend-maven-plugin</artifactId>
-          <version>2.38.0</version>
+          <version>2.39.0</version>
           <executions>
             <!-- generate Java code from Xtend code -->
             <execution>
@@ -248,6 +253,13 @@
               </configuration>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.eclipse.emf</groupId>
+              <artifactId>org.eclipse.emf.common</artifactId>
+              <version>2.42.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Updates the following plugin dependencies:

- org.eclipse.emf.codegen.ecore: 2.41.0 -> 2.42.0
- org.eclipse.emf.mwe.utils: 1.15.0 -> 1.16.0
- org.eclipse.emf.mwe2.launch: 2.21.0 -> 2.22.0
- org.eclipse.emf.mwe2.lib: 2.21.0 -> 2.22.0
- org.eclipse.xtext.common.types: 2.38.0 -> 2.39.0
- org.eclipse.xtext.xtext.generator: 2.38.0 -> 2.39.0
- org.eclipse.xtext.xtext-maven-plugin: 2.38.0 -> 2.39.0
- org.eclipse.xtend.core: 2.38.0 -> 2.39.0
- org.eclipse.xtend.xtend-maven-plugin: 2.38.0 -> 2.39.0

Also adds org.eclipse.emf.common:2.42.0 as explicit dependency of the `exec-maven-plugin` and `xtend-maven-plugin` plug-ins.
This was done to resolve build problems due to outdated versions of emf.common that these plug-ins tried to use.